### PR TITLE
:bug: :gun: Fixed double-search of current dir

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -3,7 +3,7 @@
 #######################################
 
 # Allows script.sh instead of ./script.sh
-export PATH=.:$PATH.
+export PATH=.:$PATH
 
 # Aliases
 alias view='vim -R'


### PR DESCRIPTION
Before, the current directory would be appended to whatever was the last directory in `PATH`.  Since the current directory is already searched first, we can remove this.